### PR TITLE
Change back flatcar-metadata to coreos-metadata

### DIFF
--- a/src/bin/coreos-metadata.rs
+++ b/src/bin/coreos-metadata.rs
@@ -117,7 +117,7 @@ fn init() -> Result<Config> {
     //      prepends the hyphens
     // the preprocessing will probably convert any short flags it finds into
     // long ones
-    let matches = App::new("flatcar-metadata")
+    let matches = App::new("coreos-metadata")
         .version(crate_version!())
         .arg(Arg::with_name("attributes")
              .long("attributes")

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -140,7 +140,7 @@ impl Metadata {
             .chain_err(|| format!("failed to open authorzied keys directory for user '{}'", ssh_keys_user))?;
 
         // add the ssh keys to the directory
-        authorized_keys_dir.add_keys("flatcar-metadata", self.ssh_keys.clone(), true, true)?;
+        authorized_keys_dir.add_keys("coreos-metadata", self.ssh_keys.clone(), true, true)?;
 
         // write the changes and sync the directory
         authorized_keys_dir.write()

--- a/src/providers/cloudstack/configdrive.rs
+++ b/src/providers/cloudstack/configdrive.rs
@@ -32,7 +32,7 @@ impl ConfigDrive {
         }
 
         // if not try and mount with each of the labels
-        let target = TempDir::new("flatcar-metadata")
+        let target = TempDir::new("coreos-metadata")
             .chain_err(|| "failed to create temporary directory")?;
         mount_ro(&Path::new("/dev/disk/by-label/").join(CONFIG_DRIVE_LABEL_1), target.path(), "iso9660")
             .or_else(|_| mount_ro(&Path::new("/dev/disk/by-label/").join(CONFIG_DRIVE_LABEL_2), target.path(), "iso9660"))?;


### PR DESCRIPTION
There's no need to rename this since coreos-metadata is just the name of
the project.