### PR TITLE
Cargo.toml: replace coreos with flatcar-linux for repository for alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "afterburn"
-repository = "https://github.com/coreos/afterburn"
+repository = "https://github.com/flatcar-linux/afterburn"
 license = "Apache-2.0"
 authors = [ "Stephen Demos <stephen.demos@coreos.com>",
             "Luca Bruno <lucab@debian.org>" ]


### PR DESCRIPTION
The `repository` entry should point to `github.com/flatcar-linux/afterburn`.

The change will be needed by upcoming changes in coreos-overlay, so Alpha and Edge branches could point to correct commit IDs for the flatcar-linux repo.