### PR TITLE
network: Encode information for systemd-networkd-wait-online

### DIFF
--- a/src/providers/digitalocean/mod.rs
+++ b/src/providers/digitalocean/mod.rs
@@ -161,8 +161,10 @@ impl DigitalOceanProvider {
                     routes,
                     bond: None,
                     name: None,
+                    path: None,
                     priority: None,
                     unmanaged: false,
+                    required_for_online: None,
                 },
             );
         }


### PR DESCRIPTION
The network-online.target can use systemd-networkd-wait-online.service
to wait for all interfaces to come up. It will fail if the interfaces
didn't came up but sometimes it is actually ok for some interfaces to
be down because they are unused or they are just one of two parts of a
bond. We should encode when interfaces will never come up and when it
is acceptable to have interfaces in a degraded state and which.
Extend the network logic to handle this additional configuration. For
Packet we expect the metadata to give all interfaces and any other
physical NICs can be set to "unmanaged" so that we don't wait for them.
We also allow bonds to operate with only one working link, and we don't
wait for all bonded interfaces to be configured.

**Note:** Also use this for `flatcar-2661`

Should be upstreamed.

# How to use

Use with the new Flatcar Alpha build 2661 having systemd 246 on Equinix Metal (fka Packet) t1.small.x86 and c3.small.x86 instances and check that `/usr/lib/systemd/systemd-networkd-wait-online` does not time out.

# Testing done

`cargo test` and `cargo build`, full test for the image done in https://github.com/flatcar-linux/coreos-overlay/pull/648