### PR TITLE
fix path for configdrive and metadata file names

### DIFF
--- a/src/providers/cloudstack/configdrive.rs
+++ b/src/providers/cloudstack/configdrive.rs
@@ -26,7 +26,7 @@ pub struct ConfigDrive {
 impl ConfigDrive {
     pub fn try_new() -> Result<Self> {
         // maybe its already mounted
-        let path = Path::new("/media/ConfigDrive/cloudstack/metadata/");
+        let path = Path::new("/media/configdrive/cloudstack/metadata/");
         if path.exists() {
             return Ok(ConfigDrive {
                 temp_dir: None,
@@ -122,11 +122,11 @@ impl MetadataProvider for ConfigDrive {
             "CLOUDSTACK_AVAILABILITY_ZONE",
             "availability_zone",
         )?;
-        add_value(&mut out, "CLOUDSTACK_CLOUD_IDENTIFIER", "cloud_identifier")?;
-        add_value(&mut out, "CLOUDSTACK_INSTANCE_ID", "instance_id")?;
-        add_value(&mut out, "CLOUDSTACK_LOCAL_HOSTNAME", "local_hostname")?;
-        add_value(&mut out, "CLOUDSTACK_SERVICE_OFFERING", "service_offering")?;
-        add_value(&mut out, "CLOUDSTACK_VM_ID", "vm_id")?;
+        add_value(&mut out, "CLOUDSTACK_CLOUD_IDENTIFIER", "cloud-identifier")?;
+        add_value(&mut out, "CLOUDSTACK_INSTANCE_ID", "instance-id")?;
+        add_value(&mut out, "CLOUDSTACK_LOCAL_HOSTNAME", "local-hostname")?;
+        add_value(&mut out, "CLOUDSTACK_SERVICE_OFFERING", "service-offering")?;
+        add_value(&mut out, "CLOUDSTACK_VM_ID", "vm-id")?;
 
         Ok(out)
     }


### PR DESCRIPTION
# Title: Fix for configdrive on cloudstack, not working currently.

Running afterburn on a flatcar instance in cloudstack with configdrive enabled results in metadata not been parsed, I checked the code and figured out it was a path issue and a metadata file name issue.  This should fix those issues.

## How to use

Compile the code copy over to a flatcar instance with cloudstack configdrive enabled and run it with

--provider cloudstack-configdrive --attributes /tmp/test 

/tmp/test should contain the following attributes

AFTERBURN_CLOUDSTACK_SERVICE_OFFERING=1 CPUs / 1 GB RAM
AFTERBURN_CLOUDSTACK_VM_ID=040970cd-302b-42ab-9c94-b040dac71033
AFTERBURN_CLOUDSTACK_CLOUD_IDENTIFIER=CloudStack-{b2c59cf3-2d51-43ee-ae83-dbdc6b20e345}
AFTERBURN_CLOUDSTACK_INSTANCE_ID=040970cd-302b-42ab-9c94-b040dac71033
AFTERBURN_CLOUDSTACK_LOCAL_HOSTNAME=hostname-of-this-box

## Testing done
Note the path difference for the configdrive, all lowercase not ConfigDrive

localhost metadata # df -k
Filesystem      1K-blocks   Used Available Use% Mounted on
devtmpfs           475956      0    475956   0% /dev
tmpfs              500936      0    500936   0% /dev/shm
tmpfs              200376    412    199964   1% /run
tmpfs                4096      0      4096   0% /sys/fs/cgroup
/dev/sda9         2078944 111368   1840500   6% /
/dev/mapper/usr   1007760 888432     67312  93% /usr
none               460800 341524    119276  75% /run/torcx/unpack
tmpfs              500936      0    500936   0% /media
tmpfs              500936      8    500928   1% /tmp
/dev/sr1              410    410         0 100% /media/configdrive

And filenames are - rather than _ 

localhost metadata # cd /media/configdrive/cloudstack/metadata/
localhost metadata # ls
availability-zone.txt  cloud-identifier.txt  instance-id.txt  local-hostname.txt  local-ipv4.txt  public-ipv4.txt  public-keys.txt  service-offering.txt  vm-id.txt

Running /usr/bin/coreos-metadata on a configdrive enabled VM results in a rust backtrace

localhost metadata # /usr/bin/coreos-metadata --provider cloudstack-configdrive --attributes /tmp/test
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error(Msg("failed to unmount target \'\"/tmp/afterburn.75degzGcMNzH/cloudstack/metadata\"\'"), State { next_error: Some(Sys(EINVAL)), backtrace: InternalBacktrace })', src/providers/cloudstack/configdrive.rs:159:46
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
localhost metadata # echo $?
101

Running the updated code which I've copied to /root for testing results in a correct run and update 

localhost metadata # /root/coreos-metadata --provider cloudstack-configdrive --attributes /tmp/test
localhost metadata # cat /tmp/test
AFTERBURN_CLOUDSTACK_SERVICE_OFFERING=1 CPUs / 1 GB RAM
AFTERBURN_CLOUDSTACK_VM_ID=040970cd-302b-42ab-9c94-b040dac71033
AFTERBURN_CLOUDSTACK_CLOUD_IDENTIFIER=CloudStack-{b2c59cf3-2d51-43ee-ae83-dbdc6b20e345}
AFTERBURN_CLOUDSTACK_LOCAL_HOSTNAME=hostname-of-this-box
AFTERBURN_CLOUDSTACK_INSTANCE_ID=040970cd-302b-42ab-9c94-b040dac71033

